### PR TITLE
Use consts and functions from libc

### DIFF
--- a/src/cpuset.rs
+++ b/src/cpuset.rs
@@ -26,14 +26,16 @@ impl CpuSet {
     /// Create a new `CpuSet` from a given mask. For example a u64 or a u8.
     pub fn from_mask<T>(mask: T) -> CpuSet {
         let mut cpuset = Self::new(8 * mem::size_of::<T>());
-        unsafe { ptr::write(cpuset.mut_mask_ptr() as *mut T, mask); }
+        unsafe {
+            ptr::write(cpuset.mut_mask_ptr() as *mut T, mask);
+        }
         cpuset
     }
 
     /// Create a new `CpuSet` that with one CPU set as active.
     /// Shorthand for using `new` and `set`
     pub fn single(cpu: usize) -> CpuSet {
-        let mut cpuset = Self::new(cpu+1);
+        let mut cpuset = Self::new(cpu + 1);
         cpuset.set(cpu);
         cpuset
     }
@@ -101,7 +103,11 @@ impl CpuSet {
             Err(())
         } else {
             let mut mask: u64 = 0;
-            unsafe { ptr::copy(self.mask_ptr(), (&mut mask) as *mut _ as *mut c_void, src_size) }
+            unsafe {
+                ptr::copy(self.mask_ptr(),
+                          (&mut mask) as *mut _ as *mut c_void,
+                          src_size)
+            }
             Ok(mask)
         }
     }
@@ -117,7 +123,9 @@ impl CpuSet {
     /// Fetch the affinity for a given `pid` as a `CpuSet`.
     pub fn get_affinity(pid: i32, num_cpus: usize) -> Result<CpuSet, ()> {
         let mut cpuset = CpuSet::new(num_cpus);
-        match unsafe { sched_getaffinity(pid, cpuset.len(), cpuset.mut_mask_ptr() as *mut cpu_set_t)} {
+        match unsafe {
+            sched_getaffinity(pid, cpuset.len(), cpuset.mut_mask_ptr() as *mut cpu_set_t)
+        } {
             0 => Ok(cpuset),
             _ => Err(()),
         }
@@ -132,13 +140,13 @@ mod tests {
     #[test]
     fn test_new_one_byte() {
         let mut cpuset = CpuSet::new(7);
-        assert_eq!(MASK_BITS/8, cpuset.len());
+        assert_eq!(MASK_BITS / 8, cpuset.len());
         assert_eq!(0, cpuset.as_u64().unwrap());
         cpuset = CpuSet::new(1);
-        assert_eq!(MASK_BITS/8, cpuset.len());
+        assert_eq!(MASK_BITS / 8, cpuset.len());
         assert_eq!(0, cpuset.as_u64().unwrap());
         cpuset = CpuSet::new(0);
-        assert_eq!(MASK_BITS/8, cpuset.len());
+        assert_eq!(MASK_BITS / 8, cpuset.len());
         assert_eq!(0, cpuset.as_u64().unwrap());
     }
 
@@ -166,7 +174,7 @@ mod tests {
     fn test_single_low() {
         let mask: u64 = 1 << 3;
         let cpuset = CpuSet::single(3);
-        assert_eq!(MASK_BITS/8, cpuset.len());
+        assert_eq!(MASK_BITS / 8, cpuset.len());
         assert_eq!(mask, cpuset.as_u64().unwrap());
     }
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,33 +1,3 @@
-//! See `man sched.h` and `man resource.h`
-pub mod sched {
-    //! Bindings to `sched.h`
-    use libc::*;
-
-    // http://lxr.free-electrons.com/source/include/uapi/linux/sched.h#L37
-    pub const SCHED_NORMAL: c_int = 0;
-    pub const SCHED_FIFO: c_int = 1;
-    pub const SCHED_RR: c_int = 2;
-    pub const SCHED_BATCH: c_int = 3;
-     /* SCHED_ISO: reserved but not implemented yet */
-    pub const SCHED_IDLE: c_int = 5;
-    pub const SCHED_DEADLINE: c_int = 6;
-
-    #[repr(C)]
-    pub struct SchedParam {
-        pub priority: c_int
-        // TODO: _POSIX_(THREAD)_SPORADIC_SERVER
-    }
-
-    #[link(name="c")]
-    extern {
-        pub fn sched_setscheduler(pid: pid_t, policy: c_int, param: *const SchedParam) -> c_int;
-        pub fn sched_getscheduler(pid: pid_t) -> c_int;
-        pub fn sched_setaffinity(pid: pid_t, cpusetsize: size_t, mask: *const c_void) -> c_int;
-        pub fn sched_getaffinity(pid: pid_t, cpusetsize: size_t, mask: *mut c_void) -> c_int;
-        // TODO: Other fns guaranteed by `man sched.h`
-    }
-}
-
 pub mod resource {
     //! Bindings to `sys/resource.h`
     use libc::*;

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -8,9 +8,9 @@ pub mod resource {
     pub const PRIO_USER: c_int = 2;
 
     #[link(name="c")]
-    extern {
+    extern "C" {
         pub fn setpriority(which: c_int, who: c_int, priority: c_int) -> c_int;
         pub fn getpriority(which: c_int, who: c_int) -> c_int;
-        // TODO: Other fns guaranteed by `man resource.h`
+    // TODO: Other fns guaranteed by `man resource.h`
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,10 @@ extern crate libc;
 mod ffi;
 mod sched;
 mod resource;
+#[cfg(any(target_os = "linux", target_os = "emscripten"))]
 mod cpuset;
 
 pub use sched::*;
 pub use resource::*;
+#[cfg(any(target_os = "linux", target_os = "emscripten"))]
 pub use cpuset::CpuSet;

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -7,7 +7,7 @@ use ffi::resource::*;
 pub enum Which {
     Process,
     Group,
-    User
+    User,
 }
 
 /// Set the scheduling priority for the `Which` of the calling process
@@ -29,7 +29,7 @@ pub fn set_priority(which: Which, who: i32, priority: i32) -> Result<(), ()> {
 
     match unsafe { setpriority(c_which, who, priority) } {
         0 => Ok(()),
-        _ => Err(())
+        _ => Err(()),
     }
 }
 
@@ -50,6 +50,6 @@ pub fn get_priority(which: Which, who: i32) -> Result<i32, ()> {
     let priority = unsafe { getpriority(c_which, who) };
     match errno().0 {
         0 => Ok(priority),
-        _ => Err(())
+        _ => Err(()),
     }
 }

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -1,7 +1,7 @@
 //! Set and get scheduling policies
 #[cfg(any(target_os = "linux", target_os = "android", target_os = "emscripten"))]
 use libc::{c_int, sched_param, sched_getscheduler, sched_setscheduler, SCHED_FIFO, SCHED_RR,
-    SCHED_BATCH, SCHED_IDLE, SCHED_OTHER};
+           SCHED_BATCH, SCHED_IDLE, SCHED_OTHER};
 #[cfg(any(target_os = "linux", target_os = "emscripten"))]
 use cpuset::CpuSet;
 
@@ -40,14 +40,14 @@ pub fn set_policy(pid: i32, policy: Policy, priority: i32) -> Result<(), ()> {
         Policy::RoundRobin => SCHED_RR,
         Policy::Batch => SCHED_BATCH,
         Policy::Idle => SCHED_IDLE,
-        Policy::Deadline => SCHED_DEADLINE
+        Policy::Deadline => SCHED_DEADLINE,
     };
     let params = sched_param { sched_priority: priority };
     let params_ptr: *const sched_param = &params;
 
     match unsafe { sched_setscheduler(pid, c_policy, params_ptr) } {
         0 => Ok(()),
-        _ => Err(())
+        _ => Err(()),
     }
 }
 
@@ -68,7 +68,7 @@ pub fn get_policy(pid: i32) -> Result<Policy, ()> {
         SCHED_IDLE => Ok(Policy::Idle),
         SCHED_DEADLINE => Ok(Policy::Deadline),
         -1 => Err(()),
-        policy @ _ => panic!("Policy {} does not exist", policy)
+        policy @ _ => panic!("Policy {} does not exist", policy),
     }
 }
 


### PR DESCRIPTION
I noticed the latest libc version includes a lot of the scheduling stuff. I could not build rust-scheduler with the new libc since they had a lot of naming collisions. This PR removes our own copies of most stuff and rely on libc instead.

cc @reem 