### PR TITLE
Add platform specific casts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: rust
-os: linux
+os: 
+    - linux
+    - osx
 rust:
     - stable
     - nightly

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -1,7 +1,6 @@
-//! Set and get program scheduling priority
-use errno::{Errno, errno, set_errno};
-use libc::{PRIO_PROCESS,PRIO_PGRP,PRIO_USER,setpriority,getpriority, id_t};
+use libc::{PRIO_PROCESS,PRIO_PGRP,PRIO_USER};
 
+///! Set and get program scheduling priority
 /// Which identifier type to use (`pid`, `gid`, or `uid`)
 #[allow(missing_docs)]
 pub enum Which {
@@ -26,11 +25,7 @@ pub fn set_priority(which: Which, who: i32, priority: i32) -> Result<(), ()> {
         Which::Group => PRIO_PGRP,
         Which::User => PRIO_USER,
     };
-
-    match unsafe { setpriority(c_which as u32, who as id_t, priority) } {
-        0 => Ok(()),
-        _ => Err(()),
-    }
+    platform::set_priority(c_which, who, priority)
 }
 
 /// Get the scheduling priority for the `Which` of the calling process
@@ -45,11 +40,67 @@ pub fn get_priority(which: Which, who: i32) -> Result<i32, ()> {
         Which::Group => PRIO_PGRP,
         Which::User => PRIO_USER,
     };
+    platform::get_priority(c_which, who)
+}
 
-    set_errno(Errno(0));
-    let priority = unsafe { getpriority(c_which as u32, who as id_t) };
-    match errno().0 {
-        0 => Ok(priority),
-        _ => Err(()),
+mod platform {
+    use errno::{Errno, errno, set_errno};
+    use libc::{setpriority,getpriority};
+
+    // glibc
+    #[cfg(target_env="gnu")]
+    pub fn get_priority(which: i32, who: i32) -> Result<i32, ()> {
+        set_errno(Errno(0));
+        let priority = unsafe { getpriority(which as u32, who as u32) };
+        match errno().0 {
+            0 => Ok(priority),
+            _ => Err(()),
+        }
+    }
+
+    #[cfg(target_env="gnu")]
+    pub fn set_priority(which: i32, who: i32, priority: i32) -> Result<(), ()> {
+        match unsafe { setpriority(which as u32, who as u32, priority) } {
+            0 => Ok(()),
+            _ => Err(()),
+        }
+    }
+
+    // FreeBSD
+    #[cfg(target_os="freebsd")]
+    pub fn get_priority(which: i32, who: i32) -> Result<i32, ()> {
+        set_errno(Errno(0));
+        let priority = unsafe { getpriority(which, who) };
+        match errno().0 {
+            0 => Ok(priority),
+            _ => Err(()),
+        }
+    }
+
+    #[cfg(target_os="freebsd")]
+    pub fn set_priority(which: i32, who: i32, priority: i32) -> Result<(), ()> {
+        match unsafe { setpriority(which, who, priority) } {
+            0 => Ok(()),
+            _ => Err(()),
+        }
+    }
+
+    // OS X
+    #[cfg(target_os="macos")]
+    pub fn get_priority(which: i32, who: i32) -> Result<i32, ()> {
+        set_errno(Errno(0));
+        let priority = unsafe { getpriority(which, who as u32) };
+        match errno().0 {
+            0 => Ok(priority),
+            _ => Err(()),
+        }
+    }
+
+    #[cfg(target_os="macos")]
+    pub fn set_priority(which: i32, who: i32, priority: i32) -> Result<(), ()> {
+        match unsafe { setpriority(which, who as u32, priority) } {
+            0 => Ok(()),
+            _ => Err(()),
+        }
     }
 }

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -66,6 +66,24 @@ mod platform {
         }
     }
 
+    #[cfg(target_env="musl")]
+    pub fn get_priority(which: i32, who: i32) -> Result<i32, ()> {
+        set_errno(Errno(0));
+        let priority = unsafe { getpriority(which, who as u32) };
+        match errno().0 {
+            0 => Ok(priority),
+            _ => Err(()),
+        }
+    }
+
+    #[cfg(target_env="musl")]
+    pub fn set_priority(which: i32, who: i32, priority: i32) -> Result<(), ()> {
+        match unsafe { setpriority(which, who as u32, priority) } {
+            0 => Ok(()),
+            _ => Err(()),
+        }
+    }
+
     // FreeBSD
     #[cfg(target_os="freebsd")]
     pub fn get_priority(which: i32, who: i32) -> Result<i32, ()> {

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -34,6 +34,7 @@ pub fn set_self_policy(policy: Policy, priority: i32) -> Result<(), ()> {
 /// Set the scheduling policy for a process
 #[cfg(any(target_os = "linux", target_os = "android", target_os = "emscripten"))]
 pub fn set_policy(pid: i32, policy: Policy, priority: i32) -> Result<(), ()> {
+    use std::mem;
     let c_policy = match policy {
         Policy::Other => SCHED_OTHER,
         Policy::Fifo => SCHED_FIFO,
@@ -42,7 +43,8 @@ pub fn set_policy(pid: i32, policy: Policy, priority: i32) -> Result<(), ()> {
         Policy::Idle => SCHED_IDLE,
         Policy::Deadline => SCHED_DEADLINE,
     };
-    let params = sched_param { sched_priority: priority };
+    let mut params: sched_param = unsafe { mem::zeroed() };
+    params.sched_priority = priority;
     let params_ptr: *const sched_param = &params;
 
     match unsafe { sched_setscheduler(pid, c_policy, params_ptr) } {


### PR DESCRIPTION
It's unfortunate that setpriority() / getpriority() signatures differ that much across systems :/
Compiles on linux, mac os x and freebsd now.
